### PR TITLE
Hotfix/fix skip befor limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ rethinkengine.egg-info
 .coverage
 docs/_build
 dist
+bin
+include
+lib
+man
+.python

--- a/rethinkengine/query_set.py
+++ b/rethinkengine/query_set.py
@@ -52,11 +52,11 @@ class QuerySet(object):
                     order_by_r.append(r.asc(field))
             self._cursor_obj = self._cursor_obj.order_by(*order_by_r)
 
-        if self._limit:
-            self._cursor_obj = self._cursor_obj.limit(self._limit)
-
         if self._skip:
             self._cursor_obj = self._cursor_obj.skip(self._skip)
+
+        if self._limit:
+            self._cursor_obj = self._cursor_obj.limit(self._limit)
 
         self._iter_index = 0
         self._cursor_iter = iter(self._cursor_obj.run(get_conn()))

--- a/tests/query_set/test_skip.py
+++ b/tests/query_set/test_skip.py
@@ -33,6 +33,5 @@ class SkipTestCase(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
     def test_limit_and_skip(self):
-        result = Foo.objects.limit(3).skip(1)
+        result = Foo.objects.skip(3).limit(3)
         self.assertEqual(len(result), 2)
-


### PR DESCRIPTION
Hello, 
I find a little bug in QuerySet when you use skip and limit together. Skip must be added in the _cursor_obj before limit or the query produce no results at all and no exception.

Nice tool by the way
