### PR TITLE
Changed non_atomic flag to true

### DIFF
--- a/rethinkengine/document.py
+++ b/rethinkengine/document.py
@@ -153,7 +153,7 @@ class Document(object):
         table = r.table(self.Meta.table_name)
         if self.pk:
             # TODO: implement atomic updates instead of updating entire doc
-            result = table.get(self.pk).update(doc).run(get_conn())
+            result = table.get(self.pk).update(doc, non_atomic=True).run(get_conn())
         else:
             result = table.insert(doc).run(get_conn())
 


### PR DESCRIPTION
Because GeoPointField need an expression (r.point(lat, lng)) to perform update. Non atomic flag need to be set to True. (http://rethinkdb.com/api/python/update/)

Thank you for the last merge.
